### PR TITLE
Fixing bug that causes error retrieving versions (#49)

### DIFF
--- a/src/actions/add-methods/fetchPackageVersions.ts
+++ b/src/actions/add-methods/fetchPackageVersions.ts
@@ -14,7 +14,7 @@ export default function fetchPackageVersions(selectedPackageName: string, versio
     vscode.window.setStatusBarMessage('Loading package versions...');
 
     return new Promise((resolve) => {
-        fetch(`${versionsUrl}${selectedPackageName}/index.json`, getFetchOptions(vscode.workspace.getConfiguration('http')))
+        fetch(`${versionsUrl}${selectedPackageName.toLowerCase()}/index.json`, getFetchOptions(vscode.workspace.getConfiguration('http')))
             .then((response: Response) => {
                 clearStatusBar();
                 resolve({ response, selectedPackageName });


### PR DESCRIPTION
* Fixing bug that causes error retrieving versions

This should resolve the error "Versioning information could not be retrieved from the NuGet package repository"

* Fixing issue with lowercase package name

Previous solution resulted in lowercase package name written to csproj, this resolves that.